### PR TITLE
Fix type generation breaking when encountering pixelvis_handle_t page & update types

### DIFF
--- a/generator/index.ts
+++ b/generator/index.ts
@@ -47,8 +47,7 @@ import { isWikiFunction, WikiFunctionCollection } from './wiki_types';
         .map(extractFunction);
     const classes = classFuncsPages
         .filter((p) => !p.title.includes(':') && !p.title.includes('.'))
-        .map(extractClass)
-        .filter((c): c is WikiFunctionCollection => c !== null);
+        .map(extractClass);
 
     const classResult = classes
         .map((wikiClass) =>

--- a/generator/index.ts
+++ b/generator/index.ts
@@ -12,7 +12,7 @@ import { printInterface } from './printer/interface';
 import { transformFunctionCollection } from './transformer/function_collection';
 import { extractClass } from './scrapper/extract/class';
 import { extractLibrary } from './scrapper/extract/library';
-import { isWikiFunction } from './wiki_types';
+import { isWikiFunction, WikiFunctionCollection } from './wiki_types';
 
 (async (): Promise<void> => {
     const globalFuncs = await GetPagesInCategory('Global');
@@ -47,7 +47,8 @@ import { isWikiFunction } from './wiki_types';
         .map(extractFunction);
     const classes = classFuncsPages
         .filter((p) => !p.title.includes(':') && !p.title.includes('.'))
-        .map(extractClass);
+        .map(extractClass)
+        .filter((c): c is WikiFunctionCollection => c !== null);
 
     const classResult = classes
         .map((wikiClass) =>

--- a/generator/scrapper/extract/class.ts
+++ b/generator/scrapper/extract/class.ts
@@ -1,7 +1,7 @@
 import { WikiElementKind, WikiFunctionCollection, WikiPage } from '../../wiki_types';
 import { parseMarkup } from '../util';
 
-export function extractClass(page: WikiPage): WikiFunctionCollection | null {
+export function extractClass(page: WikiPage): WikiFunctionCollection {
     const markupObj = parseMarkup(page.markup, {
         stopNodes: ['summary', 'description'],
     });
@@ -17,10 +17,7 @@ export function extractClass(page: WikiPage): WikiFunctionCollection | null {
             library: false,
             address: page.address,
         };
-    } else {
-        if (!markupObj.panel) {
-            return null;
-        }
+    } else if (markupObj.panel) {
         const classObj = markupObj.panel[0];
 
         return {
@@ -32,4 +29,11 @@ export function extractClass(page: WikiPage): WikiFunctionCollection | null {
             address: page.address,
         };
     }
+    return {
+        kind: WikiElementKind.FunctionCollection,
+        name: page.title.replace(' ', '_'),
+        description: '',
+        library: false,
+        address: page.address,
+    };
 }

--- a/generator/scrapper/extract/class.ts
+++ b/generator/scrapper/extract/class.ts
@@ -1,7 +1,7 @@
 import { WikiElementKind, WikiFunctionCollection, WikiPage } from '../../wiki_types';
 import { parseMarkup } from '../util';
 
-export function extractClass(page: WikiPage): WikiFunctionCollection {
+export function extractClass(page: WikiPage): WikiFunctionCollection | null {
     const markupObj = parseMarkup(page.markup, {
         stopNodes: ['summary', 'description'],
     });
@@ -18,6 +18,9 @@ export function extractClass(page: WikiPage): WikiFunctionCollection {
             address: page.address,
         };
     } else {
+        if (!markupObj.panel) {
+            return null;
+        }
         const classObj = markupObj.panel[0];
 
         return {

--- a/generator/scrapper/extract/function.ts
+++ b/generator/scrapper/extract/function.ts
@@ -54,6 +54,12 @@ export function extractFunction(page: WikiPage): WikiFunction | WikiStructItem {
         if (!arg.name || arg.name === '') {
             arg.name = '__unnamedArg';
         }
+        
+        if (arg.name.includes('=')) {
+            const [realName, defaultValue] = arg.name.split('=').map((s) => s.trim());
+            arg.name = realName;
+            arg.default = defaultValue;
+        }
 
         return arg;
     };

--- a/generator/scrapper/extract/function.ts
+++ b/generator/scrapper/extract/function.ts
@@ -54,7 +54,7 @@ export function extractFunction(page: WikiPage): WikiFunction | WikiStructItem {
         if (!arg.name || arg.name === '') {
             arg.name = '__unnamedArg';
         }
-        
+
         if (arg.name.includes('=')) {
             const [realName, defaultValue] = arg.name.split('=').map((s) => s.trim());
             arg.name = realName;

--- a/types/extras.d.ts
+++ b/types/extras.d.ts
@@ -1,6 +1,5 @@
 type thread = { readonly __internal__: unique symbol };
 type userdata = { readonly __internal__: unique symbol };
-type pixelvis_handle_t = { readonly __internal__: unique symbol };
 type sensor = { readonly __internal__: unique symbol };
 
 declare const SERVER: boolean;

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -4007,6 +4007,10 @@ interface CUserCmd {
      * Sets speed the client wishes to move upwards with, negative to move down.
      * 
      * See also [CUserCmd:SetSideMove](https://wiki.facepunch.com/gmod/CUserCmd:SetSideMove) and  [CUserCmd:SetForwardMove](https://wiki.facepunch.com/gmod/CUserCmd:SetForwardMove).
+     * 
+     * **Note:**
+     * >This function does **not** move the client up/down ladders. To force ladder movement, consider [CUserCMD:SetButtons](https://wiki.facepunch.com/gmod/CUserCMD:SetButtons) and use IN_FORWARD from [Enums/IN](https://wiki.facepunch.com/gmod/Enums/IN).
+     * 
      * @param speed - The new speed to request.
      */
     SetUpMove(speed: number): void;
@@ -6819,9 +6823,10 @@ interface Entity {
      * 
      * If called on server, the gibs will be spawned on the currently connected clients and will not be synchronized. Otherwise the gibs will be spawned only for the client the function is called on.
      * 
-     * Note, that this function will not remove or hide the entity it is called on.
+     * **Note:**
+     * >this function will not remove or hide the entity it is called on.
+     * 	For more expensive version of this function see [Entity:GibBreakServer](https://wiki.facepunch.com/gmod/Entity:GibBreakServer).
      * 
-     * For more expensive version of this function see [Entity:GibBreakServer](https://wiki.facepunch.com/gmod/Entity:GibBreakServer).
      * @param force - The force to apply to the created gibs.
      * @param [clr = nil] - If set, this will be color of the broken gibs instead of the entity's color.
      */
@@ -16859,7 +16864,7 @@ interface PhysObj {
     /**
      * [Shared]
      * 
-     * Sets the specified [angular velocity](https://en.wikipedia.org/wiki/Angular_velocity) on the this [PhysObj](https://wiki.facepunch.com/gmod/PhysObj)
+     * Sets the specified [angular velocity](https://en.wikipedia.org/wiki/Angular_velocity) on the [PhysObj](https://wiki.facepunch.com/gmod/PhysObj)
      * @param angularVelocity - The new velocity in `degrees/s`. (Local frame)
      */
     SetAngleVelocity(angularVelocity: Vector): void;
@@ -16867,7 +16872,7 @@ interface PhysObj {
     /**
      * [Shared]
      * 
-     * Sets the specified instantaneous [angular velocity](https://en.wikipedia.org/wiki/Angular_velocity) on the this [PhysObj](https://wiki.facepunch.com/gmod/PhysObj)
+     * Sets the specified instantaneous [angular velocity](https://en.wikipedia.org/wiki/Angular_velocity) on the [PhysObj](https://wiki.facepunch.com/gmod/PhysObj)
      * @param angularVelocity - The new velocity to set velocity.
      */
     SetAngleVelocityInstantaneous(angularVelocity: Vector): void;
@@ -17021,6 +17026,16 @@ interface PhysObj {
      * @param WorldVec - A vector in the world frame
      */
     WorldToLocalVector(WorldVec: Vector): Vector;
+
+}
+
+/**
+ * 
+ */
+interface pixelvis_handle_t {
+    
+
+    
 
 }
 
@@ -33366,7 +33381,7 @@ interface ENT {
     Folder: string,
     
     /**
-     * (Clientside) Set this to true if your entity has animations. You should also apply changes to the [ENTITY:Think](https://wiki.facepunch.com/gmod/ENTITY:Think) function from the example on that page.
+     * Set this to true if your entity has animations. You should also apply changes to the [ENTITY:Think](https://wiki.facepunch.com/gmod/ENTITY:Think) function from the example on that page.
      */
     AutomaticFrameAdvance: boolean,
     
@@ -67727,6 +67742,22 @@ declare namespace table {
      * @param source - The table you want to merge with the destination table
      */
     function Merge(destination: any, source: any): any;
+    
+    /**
+     * [Shared and Menu]
+     * 
+     * Moves elements from one part of a table to another part a given table. This is similar to assigning elements from the source table to the destination table in multiple assignments.
+     * 
+     * **Note:**
+     * >This is only available on the x86-64 versions, because of the difference in the LuaJIT version. [See here](jit.version)
+     * 
+     * @param sourceTbl - The source table from which the elements are to be moved.
+     * @param from - The start index of the source range from which the elements are to be moved.
+     * @param to - The end index of the source range until which the elements are to be moved.
+     * @param dest - The index within the destination table where the moved elements should be inserted. If this is not specified, the moved elements will be inserted at the end of the table.
+     * @param destTbl - The destination table to which the elements are to be moved. By default, this is the same as the source table.
+     */
+    function move(sourceTbl: any, from: number, to: number, dest: number, destTbl: any): any;
     
     /**
      * [Shared and Menu]

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -60414,9 +60414,9 @@ declare namespace GWEN {
      * @param y - The Y coordinate on the texture
      * @param w - Width of the area on texture
      * @param h - Height of the area on texture
-     * @param mat_override_=_null - Optional. Sets the material this function will use
+     * @param [mat_override = null] - Optional. Sets the material this function will use
      */
-    function CreateTextureCentered(x: number, y: number, w: number, h: number, mat_override_=_null: IMaterial): Function;
+    function CreateTextureCentered(x: number, y: number, w: number, h: number, mat_override?: IMaterial): Function;
     
     /**
      * [Client and Menu]
@@ -60426,9 +60426,9 @@ declare namespace GWEN {
      * @param y - The Y coordinate on the texture
      * @param w - Width of the area on texture
      * @param h - Height of the area on texture
-     * @param mat_override_=_null - Optional. Sets the material this function will use
+     * @param [mat_override = null] - Optional. Sets the material this function will use
      */
-    function CreateTextureNormal(x: number, y: number, w: number, h: number, mat_override_=_null: IMaterial): Function;
+    function CreateTextureNormal(x: number, y: number, w: number, h: number, mat_override?: IMaterial): Function;
     
     /**
      * [Client and Menu]


### PR DESCRIPTION
[`pixelvis_handle_t`'s page](https://wiki.facepunch.com/gmod/pixelvis_handle_t) does not follow the common class page format by not having the method list. I added a check for skipping such classes.

Also includes the newest generated types.